### PR TITLE
Changed how UWP packages are enumerated to resolve missing packages 

### DIFF
--- a/GloSC.sln
+++ b/GloSC.sln
@@ -1,12 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SteamTarget", "SteamTarget\SteamTarget.vcxproj", "{B12702AD-ABFB-343A-A199-8E24837244A3}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GloSC", "GloSC\GloSC.vcxproj", "{2E7F8131-0BD8-475D-B16F-20445CCF2D16}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "EnforceBindingDLL", "EnforceBindingDLL\EnforceBindingDLL.vcxproj", "{AFA0047E-7DEE-472A-AF4B-436A30459905}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GloSC_Watchdog", "GloSC_Watchdog\GloSC_Watchdog.vcxproj", "{752D3933-73A3-45E4-B139-CCB8C04BE543}"
@@ -16,6 +12,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		GloSC_install_script.iss = GloSC_install_script.iss
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GloSC", "GloSC\GloSC.vcxproj", "{2E7F8131-0BD8-475D-B16F-20445CCF2D16}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SteamTarget", "SteamTarget\SteamTarget.vcxproj", "{B12702AD-ABFB-343A-A199-8E24837244A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -24,24 +24,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.ActiveCfg = Debug|x64
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.Build.0 = Debug|x64
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.ActiveCfg = Debug|Win32
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.Build.0 = Debug|Win32
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.ActiveCfg = Release|x64
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.Build.0 = Release|x64
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.ActiveCfg = Release|Win32
-		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.Build.0 = Release|Win32
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x64.ActiveCfg = Debug|x64
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x64.Build.0 = Debug|x64
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x86.ActiveCfg = Debug|Win32
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x86.Build.0 = Debug|Win32
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x64.ActiveCfg = Release|x64
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x64.Build.0 = Release|x64
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x86.ActiveCfg = Release|Win32
-		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x86.Build.0 = Release|Win32
-		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x64.ActiveCfg = Debug|x64
-		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x64.Build.0 = Debug|x64
+		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x64.ActiveCfg = Debug|Win32
+		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x64.Build.0 = Debug|Win32
 		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x86.ActiveCfg = Debug|Win32
 		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Debug|x86.Build.0 = Debug|Win32
 		{AFA0047E-7DEE-472A-AF4B-436A30459905}.Release|x64.ActiveCfg = Release|Win32
@@ -56,6 +40,22 @@ Global
 		{752D3933-73A3-45E4-B139-CCB8C04BE543}.Release|x64.Build.0 = Release|x64
 		{752D3933-73A3-45E4-B139-CCB8C04BE543}.Release|x86.ActiveCfg = Release|Win32
 		{752D3933-73A3-45E4-B139-CCB8C04BE543}.Release|x86.Build.0 = Release|Win32
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x64.ActiveCfg = Debug|x64
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x64.Build.0 = Debug|x64
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x86.ActiveCfg = Debug|Win32
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Debug|x86.Build.0 = Debug|Win32
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x64.ActiveCfg = Release|x64
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x64.Build.0 = Release|x64
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x86.ActiveCfg = Release|Win32
+		{2E7F8131-0BD8-475D-B16F-20445CCF2D16}.Release|x86.Build.0 = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.ActiveCfg = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x64.Build.0 = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.ActiveCfg = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Debug|x86.Build.0 = Debug|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.ActiveCfg = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x64.Build.0 = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.ActiveCfg = Release|Win32
+		{B12702AD-ABFB-343A-A199-8E24837244A3}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GloSC/GloSC.cpp
+++ b/GloSC/GloSC.cpp
@@ -672,12 +672,7 @@ void GloSC::on_pbUWP_clicked()
 								}
 							}
 
-							QString PRAID = QString::fromWCharArray(appId);
-							CoTaskMemFree(appId);
-							if (!PRAID.isEmpty()) {
-								AppUMId = AppUMId.append("!");
-								AppUMId = AppUMId.append(PRAID);
-							}
+							
 							if (!SUCCEEDED(hr))
 								AppName = QString::fromWCharArray(package->Id->Name->Data());
 							else
@@ -696,6 +691,12 @@ void GloSC::on_pbUWP_clicked()
 						AppName = QString::fromWCharArray(package->Id->Name->Data());
 					}
 					
+					QString PRAID = QString::fromWCharArray(appId);
+					CoTaskMemFree(appId);
+					if (!PRAID.isEmpty()) {
+						AppUMId = AppUMId.append("!");
+						AppUMId = AppUMId.append(PRAID);
+					}
 			
 					const UWPPair uwpPair = {
 						AppName,

--- a/GloSC/GloSC.vcxproj
+++ b/GloSC/GloSC.vcxproj
@@ -21,7 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2E7F8131-0BD8-475D-B16F-20445CCF2D16}</ProjectGuid>
     <Keyword>Qt4VSv1.0</Keyword>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
@@ -65,6 +65,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <AdditionalUsingDirectories>C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\8.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\UnionMetadata\10.0.18362.0;C:\Program Files %28x86%29\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <CompileAsWinRT>true</CompileAsWinRT>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -83,6 +85,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <AdditionalUsingDirectories>C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\8.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\UnionMetadata\10.0.18362.0;C:\Program Files %28x86%29\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -100,6 +104,8 @@
       <DebugInformationFormat />
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <AdditionalUsingDirectories>C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\8.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\UnionMetadata\10.0.18362.0;C:\Program Files %28x86%29\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <CompileAsWinRT>true</CompileAsWinRT>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -118,6 +124,8 @@
       </DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <AdditionalUsingDirectories>C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.FoundationContract\3.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\References\10.0.18362.0\Windows.Foundation.UniversalApiContract\8.0.0.0;C:\Program Files %28x86%29\Windows Kits\10\UnionMetadata\10.0.18362.0;C:\Program Files %28x86%29\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\vcpackages;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -301,7 +309,7 @@
   </ImportGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties MocDir=".\GeneratedFiles\$(ConfigurationName)" UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" lupdateOptions="" lupdateOnBuild="0" lreleaseOptions="" Qt5Version_x0020_Win32="$(DefaultQtVersion)" Qt5Version_x0020_x64="5.10.1_x64" MocOptions="" />
+      <UserProperties MocDir=".\GeneratedFiles\$(ConfigurationName)" UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" lupdateOptions="" lupdateOnBuild="0" lreleaseOptions="" Qt5Version_x0020_Win32="msvc2017" Qt5Version_x0020_x64="msvc2017_64" MocOptions="" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>


### PR DESCRIPTION
The previous method of enumerating UWP packages relied on registry entries in Windows.Launch, which was generally missing a lot of packages.

This commit uses PackageManager and IAppxManifestReader to enumerate packages, read the package relative app id (PRAID) and app name from the Manifest XML, then construct the uwp_pairs as before.

Should resolve #86. 