### PR TITLE
Fix OpenSSL License date in OpenSSL License.txt

### DIFF
--- a/redist/OpenSSL License.txt
+++ b/redist/OpenSSL License.txt
@@ -12,7 +12,7 @@
   ---------------
 
 /* ====================================================================
- * Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.
+ * Copyright (c) 1998-2019 The OpenSSL Project.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
Fix the OpenSSL License date in the 'OpenSSL License.txt' file. According to the openssl.org license, the copyright is issued as "1998-2019 The OpenSSL Project." however in the provided OpenSSL License text file it states "1998-2016 The OpenSSL Project."